### PR TITLE
Lobby-list: Add filtering lobbies by available classes

### DIFF
--- a/src/app/app.filter.js
+++ b/src/app/app.filter.js
@@ -5,7 +5,8 @@
   app.filter('capitalize', capitalize);
   app.filter('reverse', reverse);
   app.filter('trusted', trusted);
-  app.filter('classNameFilter', classNameFilter);
+  app.filter('slotNameToClassName', slotNameToClassName);
+  app.filter('stripSlotNameNumber', stripSlotNameNumber);
   app.filter('secondsToMinutes', secondsToMinutes);
   app.filter('unique', unique);
 
@@ -34,9 +35,30 @@
   }
 
   /** @ngInject */
-  function classNameFilter() {
-    return function(className) {
-      return className.replace(/\d+$/, "");
+  function stripSlotNameNumber() {
+    return function(slotName) {
+      return slotName.replace(/\d+$/, "");
+    };
+  }
+
+  /** @ngInject */
+  function slotNameToClassName() {
+    var classSynonyms = {
+      roamer: 'soldier',
+      pocket: 'soldier'
+    };
+
+    var stripNumberFilter = stripSlotNameNumber();
+
+    return function(slotName) {
+      slotName = stripNumberFilter(slotName);
+
+      var className = slotName;
+      if (classSynonyms.hasOwnProperty(slotName)) {
+        className = classSynonyms[slotName];
+      }
+
+      return className;
     };
   }
 

--- a/src/app/app.settings.js
+++ b/src/app/app.settings.js
@@ -28,6 +28,17 @@
         pl:             {name: 'Payload'},
         koth:           {name: 'King of the hill'},
         others:         {name: 'Other gamemodes'}
+      },
+      classes: {
+        scout:          {name: 'Scout' },
+        soldier:        {name: 'Soldier' },
+        pyro:           {name: 'Pyro' },
+        demoman:        {name: 'Demoman' },
+        heavy:          {name: 'Heavy' },
+        engineer:       {name: 'Engineer' },
+        medic:          {name: 'Medic' },
+        sniper:         {name: 'Sniper' },
+        spy:            {name: 'Spy' }
       }
     };
 
@@ -134,7 +145,7 @@
       settingsService.getSettings = function(callback) {
         callback = callback || angular.noop;
 
-        if(!alreadyLoadedFromBackend) {          
+        if(!alreadyLoadedFromBackend) {
           var handler = $rootScope.$on('settings-loaded-from-backend', function() {
             callback(settings);
             handler();

--- a/src/app/pages/lobby/list/lobby-list.filter.js
+++ b/src/app/pages/lobby/list/lobby-list.filter.js
@@ -5,6 +5,28 @@
     .module('tf2stadium.services')
     .filter('LobbyListSettingsFilter', LobbyListSettingsFilter);
 
+  var CLASS_SYNONYMS = {
+    roamer: 'soldier',
+    pocket: 'soldier',
+    scout1: 'scout',
+    scout2: 'scout'
+  };
+
+  function maybeClassName(slot) {
+    if (!(slot.blu.filled && slot.red.filled)) {
+      var className = slot.class;
+      if (CLASS_SYNONYMS.hasOwnProperty(className)) {
+        className = CLASS_SYNONYMS[className];
+      }
+      return className;
+    }
+    return false;
+  }
+
+  function truthy(x) {
+    return !!x;
+  }
+
   /** @ngInject */
   function LobbyListSettingsFilter(Settings, Config) {
 
@@ -20,17 +42,22 @@
         var lobby = lobbies[key];
         lobby.region = "eu";
 
-        if (settings[lobby.region] &&
-          settings[lobby.type] &&
-          settings[lobby.map.substr(0, lobby.map.indexOf('_'))]
+        var availableClasses = lobby.classes.map(maybeClassName).filter(truthy);
 
-          || (Config.debug && lobby.type === 'Debug')) {
+        if (settings[lobby.region] &&
+            settings[lobby.type] &&
+            settings[lobby.map.substr(0, lobby.map.indexOf('_'))] &&
+            availableClasses.some(function(className) {
+              return settings[className];
+            })
+
+            || (Config.debug && lobby.type === 'Debug')) {
           filteredList[key] = lobby;
         }
       }
 
       return filteredList;
     };
-    
+
   }
 })();

--- a/src/app/pages/lobby/list/lobby-list.filter.js
+++ b/src/app/pages/lobby/list/lobby-list.filter.js
@@ -42,7 +42,8 @@
         var lobby = lobbies[key];
         lobby.region = "eu";
 
-        var availableClasses = lobby.classes.map(maybeClassName).filter(truthy);
+        var classes = angular.isArray(lobby.classes)? lobby.classes : [];
+        var availableClasses = classes.map(slotNameToClassName).filter(truthy);
 
         if (settings[lobby.region] &&
             settings[lobby.type] &&

--- a/src/app/pages/lobby/list/lobby-list.html
+++ b/src/app/pages/lobby/list/lobby-list.html
@@ -7,13 +7,13 @@
   <div flex class="lobby-main">
     <div flex class="lobby-classes">
       <div ng-repeat="class in lobbyInformation.classes track by $index"
-           class="class-button lobby-icon-{{::class.class | classNameFilter}}"
+           class="class-button lobby-icon-{{::class.class | stripSlotNameNumber}}"
            ng-class="{'sheet' : !class.blu.filled || !class.red.filled}">
         <md-button ng-repeat="(team, slot) in class"
           ng-if="!slot.filled && team!='class'"
           ng-class="['join-slot', team]" ng-click="lobbyList.join(lobbyInformation.id, team, class.class, $event)">
           <md-tooltip>
-            Join {{::team}} {{::class.class | classNameFilter}} slot
+            Join {{::team}} {{::class.class | stripSlotNameNumber}} slot
           </md-tooltip>
           <span></span>
         </md-button>

--- a/src/app/pages/lobby/page/lobby-page.html
+++ b/src/app/pages/lobby/page/lobby-page.html
@@ -17,7 +17,7 @@
     <h1>Red</h1>
   </div>
   <div ng-repeat="class in lobbyPage.lobbyInformation.classes track by class.class" class="class-row">
-    <div aria-label="Join {{::key}} {{::class.class | classNameFilter}}"
+    <div aria-label="Join {{::key}} {{::class.class | stripSlotNameNumber}}"
       ng-repeat="(key, slot) in class track by key"
       ng-if="key!='class'"
       ng-click="slot.player ? angular.noop() : lobbyPage.join(lobbyPage.lobbyInformation.id, key, class.class)"
@@ -54,10 +54,10 @@
             </md-menu-item>
           </md-menu-content>
         </md-menu>
-        <md-checkbox 
+        <md-checkbox
           ng-show="lobbyPage.lobbyInformation.state==2
             || ($root.userProfile.steamid==slot.player.steamid && lobbyPage.lobbyInformation.state==1)"
-          ng-checked="slot.ready 
+          ng-checked="slot.ready
             || (lobbyPage.playerPreReady && $root.userProfile.steamid==slot.player.steamid)" ng-click="lobbyPage.preReadyUp()"
             aria-label="Player ready">
         </md-checkbox>
@@ -73,6 +73,6 @@
       </div>
       <img ng-if="slot.filled" ng-src="{{::slot.player.avatar.replace('.jpg', '_medium.jpg') | trusted}}" class="slot-avatar">
     </div>
-    <div class="class-button lobby-icon-{{::class.class | classNameFilter}}"></div>
+    <div class="class-button lobby-icon-{{::class.class | stripSlotNameNumber}}"></div>
   </div>
 </div>


### PR DESCRIPTION
Fix #43 by letting users filter displayed lobbies based on which class slots are open.

Currently it just treats roamer/pocket as normal 'soldier'.