### PR TITLE
'gulp lint' and 'gulp lint-fix'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ It uses [AngularJS](https://angularjs.org/) as its framework, [Gulp](http://gulp
 * Execute `gulp serve` and and a Webbrowser Tab should open. This needs a full npm dependency installation (`npm install`); using `npm install --production` will result in a missing module error.
 * Execute `gulp` or `gulp build` when you want to build the project. It will output the files to `dist/`.
 
+##Development
+
+After making changes, run `gulp lint` to check for common errors or whitespace formatting issues. Most simple formatting errors can be automatically fixed with `gulp lint-fix`.
+
 ##License
 
 Released under the [GPLv3 License (GPLv3)](https://github.com/TF2Stadium/Frontend/blob/master/LICENSE).

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
     - bower install
 test:
   override:
-    - gulp scripts
+    - gulp lint
 deployment:
   master:
     branch: master

--- a/gulp/lint.js
+++ b/gulp/lint.js
@@ -6,9 +6,24 @@ var conf = require('./conf');
 
 var $ = require('gulp-load-plugins')();
 
-gulp.task('lint', function () {
-  return gulp.src(path.join(conf.paths.src, '/app/**/*.js'))
-    .pipe($.eslint())
+function isFixed(file) {
+  // Has ESLint fixed the file contents?
+  return file.eslint != null && file.eslint.fixed;
+}
+
+function runLinter(tryToFix) {
+  var codePath = path.join(conf.paths.src, 'app');
+  return gulp.src(path.join(codePath, '**/*.js'))
+    .pipe($.eslint({ fix: tryToFix }))
     .pipe($.eslint.format())
+    .pipe($.if(isFixed, gulp.dest(codePath)))
     .pipe($.eslint.failAfterError());
+}
+
+gulp.task('lint', function () {
+  return runLinter(false);
+});
+
+gulp.task('lint-fix', function () {
+  return runLinter(true);
 });

--- a/gulp/lint.js
+++ b/gulp/lint.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var path = require('path');
+var gulp = require('gulp');
+var conf = require('./conf');
+
+var $ = require('gulp-load-plugins')();
+
+gulp.task('lint', function () {
+  return gulp.src(path.join(conf.paths.src, '/app/**/*.js'))
+    .pipe($.eslint())
+    .pipe($.eslint.format())
+    .pipe($.eslint.failAfterError());
+});

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-uglify": "~1.2.0",
     "gulp-useref": "~1.2.0",
     "gulp-util": "~3.0.5",
+    "gulp-if": "^2.0.0",
     "lodash": "~3.9.3",
     "wiredep": "~2.2.2",
     "wrench": "~1.5.8"

--- a/src/app/pages/lobby/lobby.factory.js
+++ b/src/app/pages/lobby/lobby.factory.js
@@ -72,33 +72,33 @@
       scope.$on('$destroy', handler);
     };
 
-    factory.kick = function(lobbyID, steamID) {
+    factory.kick = function (lobbyID, steamID) {
       var payload = {
         'id': lobbyID,
         'steamid': steamID
       };
 
-      Websocket.emitJSON('lobbyKick', payload, function(response) {
+      Websocket.emitJSON('lobbyKick', payload, function (response) {
         if (response.success) {
           Notifications.toast({message: 'Player kicked'});
         }
       });
     };
 
-    factory.ban = function(lobbyID, steamID) {
+    factory.ban = function (lobbyID, steamID) {
       var payload = {
         'id': lobbyID,
         'steamid': steamID
       };
 
-      Websocket.emitJSON('lobbyBan', payload, function(response) {
+      Websocket.emitJSON('lobbyBan', payload, function (response) {
         if (response.success) {
           Notifications.toast({message: 'Player banned'});
         }
       });
     };
 
-    factory.join = function(lobbyID, team, position) {
+    factory.join = function (lobbyID, team, position) {
       var payload = {
         'id': lobbyID,
         'team': team,
@@ -108,7 +108,7 @@
       Websocket.emitJSON('lobbyJoin', payload);
     };
 
-    factory.leaveSlot = function(lobbyID) {
+    factory.leaveSlot = function (lobbyID) {
       var payload = {
         'id': lobbyID
       };
@@ -116,7 +116,7 @@
       Websocket.emitJSON('lobbyLeave', payload);
     };
 
-    factory.goToLobby = function(lobby) {
+    factory.goToLobby = function (lobby) {
       $state.go('lobby-page', {lobbyID: lobby});
     };
 

--- a/src/app/pages/lobby/page/lobby-page.controller.js
+++ b/src/app/pages/lobby/page/lobby-page.controller.js
@@ -62,15 +62,15 @@
       $window.open('http://steamcommunity.com/profiles/' + steamId, '_blank');
     };
 
-    vm.kick = function(playerSummary) {
+    vm.kick = function (playerSummary) {
       LobbyService.kick(vm.lobbyInformation.id, playerSummary.steamid);
     };
 
-    vm.ban = function(playerSummary) {
+    vm.ban = function (playerSummary) {
       LobbyService.ban(vm.lobbyInformation.id, playerSummary.steamid);
     };
 
-    vm.leaveSlot = function() {
+    vm.leaveSlot = function () {
       LobbyService.leaveSlot(vm.lobbyInformation.id);
     };
 


### PR DESCRIPTION
Using 'gulp scripts' caused circleci to ignore linter errors because the gulp task itself didnt fail.