### PR TITLE
lobby-page: fix slot :focus border pushing icons

### DIFF
--- a/src/app/pages/lobby/page/lobby-page.html
+++ b/src/app/pages/lobby/page/lobby-page.html
@@ -1,90 +1,92 @@
 <div id="lobby-join-information" class="sheet"
-  ng-if="lobbyPage.lobbyJoinInformation.id && lobbyPage.lobbyJoinInformation.id==lobbyPage.lobbyInformation.id">
+     ng-if="lobbyPage.lobbyJoinInformation.id && lobbyPage.lobbyJoinInformation.id==lobbyPage.lobbyInformation.id">
   <div class="row">
     <md-button ng-click="lobbyPage.joinTF2Server()">Connect to server</md-button>
     <md-button ng-if="!lobbyPage.showConnectString"
-      ng-click="lobbyPage.showConnectString=true">
+               ng-click="lobbyPage.showConnectString=true">
       Show the connect string
     </md-button>
     <span flex ng-if="lobbyPage.showConnectString">
       {{lobbyPage.lobbyJoinInformation.connectString}}
     </span>
-    <md-button data-clipboard-text="{{lobbyPage.lobbyJoinInformation.connectString}}" class="clipboard-button">Copy to clipboard</md-button>   
+    <md-button data-clipboard-text="{{lobbyPage.lobbyJoinInformation.connectString}}" class="clipboard-button">Copy to clipboard</md-button>
   </div>
   <div class="row">
     <md-button ng-click="lobbyPage.joinMumbleServer()">Connect to Mumble</md-button>
     <md-button ng-if="!lobbyPage.showMumbleInformation"
-      ng-click="lobbyPage.showMumbleInformation=true">
+               ng-click="lobbyPage.showMumbleInformation=true">
       Show the connect info
     </md-button>
     <span flex ng-if="lobbyPage.showMumbleInformation">
       {{lobbyPage.lobbyJoinInformation.mumbleInformation}}
     </span>
-    <md-button data-clipboard-text="{{lobbyPage.lobbyJoinInformation.mumbleInformation}}" class="clipboard-button">Copy to clipboard</md-button>   
+    <md-button data-clipboard-text="{{lobbyPage.lobbyJoinInformation.mumbleInformation}}" class="clipboard-button">Copy to clipboard</md-button>
   </div>
 </div>
 
 <div id="slots"
-  ng-show="lobbyPage.shouldShowLobbyInformation()">
+     ng-show="lobbyPage.shouldShowLobbyInformation()">
   <div class="classes-title">
     <h1>Blu</h1>
     <h1>Red</h1>
   </div>
   <div ng-repeat="class in lobbyPage.lobbyInformation.classes track by class.class" class="class-row">
-    <div aria-label="Join {{::team}} {{::class.class | stripSlotNameNumber}}"
-      ng-repeat="(team, slot) in {blu: class.blu, red: class.red} track by team"
-      ng-click="slot.filled ? angular.noop() : lobbyPage.join(lobbyPage.lobbyInformation.id, team, class.class)"
-      ng-class="{'sheet low clickable' : !slot.filled}"
-      class="slot-button"
-      md-ink-ripple>
-      <div ng-if="slot.filled">
-        <md-menu>
-          <md-button class="more-button"
-            aria-label="More"
-            ng-click="slot.filled ? $mdOpenMenu($event) : lobbyPage.join(lobbyPage.lobbyInformation.id, team, class.class)">
-            <img src="/assets/img/icon-more.svg">
-          </md-button>
-          <md-menu-content width="4">
-            <md-menu-item>
-              <md-button ng-click="lobbyPage.goToProfile(slot.player.steamid)">
-                Steam profile
-              </md-button>
-            </md-menu-item>
-            <md-menu-item ng-if="$root.userProfile.steamid==lobbyPage.lobbyInformation.leader.steamid || $root.userProfile.role=='administrator'">
-              <md-button ng-click="lobbyPage.kick(slot.player)">
-                Kick player from slot
-              </md-button>
-            </md-menu-item>
-            <md-menu-item ng-if="$root.userProfile.steamid==lobbyPage.lobbyInformation.leader.steamid || $root.userProfile.role=='administrator'">
-              <md-button ng-click="lobbyPage.ban(slot.player)">
-                Ban player from lobby
-              </md-button>
-            </md-menu-item>
-            <md-menu-item ng-if="$root.userProfile.steamid==slot.player.steamid">
-              <md-button ng-click="lobbyPage.leaveSlot()">
-                Leave slot
-              </md-button>
-            </md-menu-item>
-          </md-menu-content>
-        </md-menu>
-        <md-checkbox 
-          ng-if="lobbyPage.lobbyInformation.state==2
-            || ($root.userProfile.steamid==slot.player.steamid && lobbyPage.lobbyInformation.state==1)"
-          ng-checked="slot.ready
-            || (lobbyPage.playerPreReady && $root.userProfile.steamid==slot.player.steamid)" ng-click="lobbyPage.preReadyUp()"
-            aria-label="Player ready">
-        </md-checkbox>
-      </div>
-      <div flex class="slot-info" ng-if="slot.filled">
-        <span class="slot-playername">{{::slot.player.name}}</span>
-        <div class="slot-misc">
-          <div flex ng-if="!slot.ready && $root.userProfile.steamid==slot.player.steamid">
-            <span>{{lobbyPage.playerPreReady ? (lobbyPage.preReadyUpTimer | secondsToMinutes) : 'Pre-ready up!'}}</span>
-          </div>
-          <div><span>{{::slot.player.lobbiesPlayed}}</span><span>lobbies</span></div>
+    <div class="slot-button-wrapper"
+         ng-repeat="(team, slot) in {blu: class.blu, red: class.red} track by team">
+      <div aria-label="Join {{::team}} {{::class.class | stripSlotNameNumber}}"
+           ng-click="slot.filled ? angular.noop() : lobbyPage.join(lobbyPage.lobbyInformation.id, team, class.class)"
+           ng-class="{'sheet low clickable' : !slot.filled}"
+           class="slot-button"
+           md-ink-ripple>
+        <div ng-if="slot.filled">
+          <md-menu>
+            <md-button class="more-button"
+                       aria-label="More"
+                       ng-click="slot.filled ? $mdOpenMenu($event) : lobbyPage.join(lobbyPage.lobbyInformation.id, team, class.class)">
+              <img src="/assets/img/icon-more.svg">
+            </md-button>
+            <md-menu-content width="4">
+              <md-menu-item>
+                <md-button ng-click="lobbyPage.goToProfile(slot.player.steamid)">
+                  Steam profile
+                </md-button>
+              </md-menu-item>
+              <md-menu-item ng-if="$root.userProfile.steamid==lobbyPage.lobbyInformation.leader.steamid || $root.userProfile.role=='administrator'">
+                <md-button ng-click="lobbyPage.kick(slot.player)">
+                  Kick player from slot
+                </md-button>
+              </md-menu-item>
+              <md-menu-item ng-if="$root.userProfile.steamid==lobbyPage.lobbyInformation.leader.steamid || $root.userProfile.role=='administrator'">
+                <md-button ng-click="lobbyPage.ban(slot.player)">
+                  Ban player from lobby
+                </md-button>
+              </md-menu-item>
+              <md-menu-item ng-if="$root.userProfile.steamid==slot.player.steamid">
+                <md-button ng-click="lobbyPage.leaveSlot()">
+                  Leave slot
+                </md-button>
+              </md-menu-item>
+            </md-menu-content>
+          </md-menu>
+          <md-checkbox
+             ng-if="lobbyPage.lobbyInformation.state==2
+                    || ($root.userProfile.steamid==slot.player.steamid && lobbyPage.lobbyInformation.state==1)"
+             ng-checked="slot.ready
+                         || (lobbyPage.playerPreReady && $root.userProfile.steamid==slot.player.steamid)" ng-click="lobbyPage.preReadyUp()"
+             aria-label="Player ready">
+          </md-checkbox>
         </div>
+        <div flex class="slot-info" ng-if="slot.filled">
+          <span class="slot-playername">{{::slot.player.name}}</span>
+          <div class="slot-misc">
+            <div flex ng-if="!slot.ready && $root.userProfile.steamid==slot.player.steamid">
+              <span>{{lobbyPage.playerPreReady ? (lobbyPage.preReadyUpTimer | secondsToMinutes) : 'Pre-ready up!'}}</span>
+            </div>
+            <div><span>{{::slot.player.lobbiesPlayed}}</span><span>lobbies</span></div>
+          </div>
+        </div>
+        <img ng-if="slot.filled" ng-src="{{::slot.player.avatar.replace('.jpg', '_medium.jpg') | trusted}}" class="slot-avatar">
       </div>
-      <img ng-if="slot.filled" ng-src="{{::slot.player.avatar.replace('.jpg', '_medium.jpg') | trusted}}" class="slot-avatar">
     </div>
     <div class="class-button lobby-icon-{{::class.class | stripSlotNameNumber}}">
       <md-tooltip md-direction="bottom">

--- a/src/scss/pages/lobby-page/_lobby-page.scss
+++ b/src/scss/pages/lobby-page/_lobby-page.scss
@@ -111,48 +111,58 @@
   }
 }
 
-.slot-button {
-  @include flex (row, space-between, center);
+.slot-button-wrapper {
   height: 100%;
   width: 100%;
   padding: 0;
   margin: 0;
   flex: 1;
-  position: relative;
-  line-height: normal !important; //otherwise can't multiline inside md-button
-  border-radius: 3px; //overriding .class-button .md-button
-  transition: all .3s ease-out;
-  overflow: hidden;
 
   &:nth-child(2) {
-    flex-direction: row-reverse;
     order: 3;
 
-    .firefox-bug-container {
+    .slot-button {
       flex-direction: row-reverse;
-    }
 
-    .slot-info {
-      align-items: flex-start;
-    }
+      .firefox-bug-container {
+        flex-direction: row-reverse;
+      }
 
-    .slot-misc {
-      flex-direction: row-reverse;
-      text-align: right;
-    }
+      .slot-info {
+        align-items: flex-start;
+      }
 
-    .slot-playername {
-      text-align: left;
+      .slot-misc {
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+
+      .slot-playername {
+        text-align: left;
+      }
     }
   }
 
-  md-checkbox {
-    margin: 0 auto;
-    width: 15px;
-  }
+  .slot-button {
+    @include flex (row, space-between, center);
+    height: 100%;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    position: relative;
+    line-height: normal !important; //otherwise can't multiline inside md-button
+    border-radius: 3px; //overriding .class-button .md-button
+    transition: all .3s ease-out;
+    overflow: hidden;
 
-  &:not(.sheet) > .md-ripple-container {
-    display: none;
+    md-checkbox {
+      margin: 0 auto;
+      width: 15px;
+    }
+
+    &:not(.sheet) > .md-ripple-container {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes the class icon in a slot row on the lobby-page from being moved back and forth when a slot gets :focus (which happens whenever you click to move between slots)

The cause is an unintuitive interaction between flexbox layouts and `box-sizing: border-box`; increasing the border of an item in the flexbox will make it take up more space than sibling elements with the same `flex` value.

See this fiddle for an example: (along with the wrapper div fix which I implement in this PR)

http://jsfiddle.net/gpittarelli/gc0eejgp/