### PR TITLE
Style: fix :focus outline moving .sheet elements.

### DIFF
--- a/src/scss/main/__helpers.scss
+++ b/src/scss/main/__helpers.scss
@@ -67,6 +67,13 @@
 
   &:not(.flat):focus {
     @extend %md-whiteframe-z3;
+
+    &:after {
+      @extend .fill-parent;
+      content: '';
+      border-radius: 3px;
+      box-sizing: border-box;  
+    }
   }
 
   &.clickable {

--- a/src/scss/main/_theme.scss
+++ b/src/scss/main/_theme.scss
@@ -76,7 +76,7 @@ $themes-list: (
         background-color: $hover-color;
       }
 
-      &:not(.flat):focus {
+      &:not(.flat):focus:after {
         border: 2px solid $main-color;
       }
     }


### PR DESCRIPTION
Fixes the issue present in #75 in a different way.