### PR TITLE
Chat service sorts messages by id

### DIFF
--- a/src/app/shared/comment-box/chat.service.js
+++ b/src/app/shared/comment-box/chat.service.js
@@ -95,6 +95,13 @@
       $rootScope.$emit('chat-message', message);
     });
 
+    Websocket.onJSON('chatHistoryClear', function (data) {
+      // Note: ChatRooms may have pointers to the arrays in
+      // chatRoomLogs, so we have to mutate the actual logs rather
+      // than just assign a new empty array.
+      getChatRoom(data.room).length = 0;
+    });
+
     return factory;
   }
 })();

--- a/src/app/shared/comment-box/chat.service.js
+++ b/src/app/shared/comment-box/chat.service.js
@@ -68,16 +68,31 @@
 
     Websocket.onJSON('chatReceive', function (message) {
       message.timestamp = new Date(message.timestamp * 1000);
-      getChatRoom(message.room).push(message);
+
+      var log = getChatRoom(message.room);
+
+      // Insert messages in sorted order (sorted by message id)
+      if (log.length === 0 || log[log.length - 1].id < message.id) {
+        log.push(message);
+      } else {
+        // performance likely isn't an issue, but since the log is
+        // sorted by id, it would be better to use a binary search
+        // here (also, use ES6 findIndex when available).
+        var insertIdx = 0;
+        while (log[insertIdx].id < message.id) {
+          insertIdx++;
+        }
+        if (log[insertIdx].id === message.id) {
+          // Same message id? Overwrite the logged message
+          log[insertIdx] = message;
+        } else {
+          // else insert it into the array (yeah, splice is far from
+          // efficient, but this should be very rare).
+          log.splice(insertIdx, 0, message);
+        }
+      }
+
       $rootScope.$emit('chat-message', message);
-    });
-
-
-    Websocket.onJSON('chatHistoryClear', function (data) {
-      // Note: ChatRooms may have pointers to the arrays in
-      // chatRoomLogs, so we have to mutate the actual logs rather
-      // than just assign a new empty array.
-      getChatRoom(data.room).length = 0;
     });
 
     return factory;

--- a/test/karma/chat.service.js
+++ b/test/karma/chat.service.js
@@ -140,7 +140,6 @@ describe('Service: ChatService', function () {
     var msg3 = makeTestMessage();
     msg3.id = 3;
 
-    // Note the wrong order
     onChatReceive(msg1);
     onChatReceive(msg2);
     onChatReceive(msg3);
@@ -150,5 +149,36 @@ describe('Service: ChatService', function () {
     expect(ChatService.getRooms()[0].messages.length).to.equal(3);
     onChatHistoryClear({ room: msg1.room });
     expect(ChatService.getRooms()[0].messages.length).to.equal(0);
+  });
+
+  it('should overwrite messages with the same id in the same room', function () {
+    var onJSONcalls = mockWebsocket.onJSON.args;
+    var onChatReceive = onJSONcalls.filter(function (args) {
+      return args[0] === 'chatReceive';
+    })[0][1];
+
+    var onChatHistoryClear = onJSONcalls.filter(function (args) {
+      return args[0] === 'chatHistoryClear';
+    })[0][1];
+
+    expect(onChatHistoryClear).to.be.a('function');
+
+    var msg1 = makeTestMessage();
+    msg1.id = 1;
+
+    var msg2 = makeTestMessage();
+    msg2.id = 2;
+
+    var msg3 = makeTestMessage();
+    msg3.id = 1;
+    msg3.message = msg1.message + 'unique';
+
+    onChatReceive(msg1);
+    onChatReceive(msg2);
+    expect(ChatService.getRooms()[0].messages.length).to.equal(2);
+    onChatReceive(msg3);
+    expect(ChatService.getRooms()[0].messages.length).to.equal(2);
+
+    expect(ChatService.getRooms()[0].messages[0].message).to.equal(msg3.message);
   });
 });


### PR DESCRIPTION
This change also allows subsequent chatReceive messages with the same id (and in the same room) to overwrite previous messages.