### PR TITLE
style: allow y-scrolling for short viewports

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -51,6 +51,8 @@
     <!--[if lt IE 10]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
+    <aside id="toasts"></aside>
+
     <header id="header" ng-if="$root.backendAuthenticated">
       <md-toolbar id="header-toolbar">
         <div class="header-toolbar-content">
@@ -106,8 +108,6 @@
         <md-content flex ui-view="content" id="main-content"></md-content>
       </div>
     </main>
-    <aside id="toasts"></aside>
-
 
     <!-- build:js(src) scripts/vendor.js -->
     <!-- bower:js -->

--- a/src/scss/main/_elements.scss
+++ b/src/scss/main/_elements.scss
@@ -36,7 +36,7 @@
       content: "";
       background:{
         size: $class-button-background-width;
-        position: ($class-button-width - $class-button-background-width) / 2 
+        position: ($class-button-width - $class-button-background-width) / 2
                   ($class-button-height - $class-button-background-height) / 2;
         repeat: no-repeat;
       }
@@ -179,12 +179,18 @@
   //@include flex (row, space-between, center);
   height: $toast-height;
   width: 100%;
-  margin: 0;
   max-width: $full-width;
-  bottom: 0 !important;
   will-change: transform;
   transition: all .3s .15s ease-out;
   border-radius: 0;
+
+  // Override some angular positioning (since we're moving the toasts
+  // to the bottom of the viewport by ourselves)
+  bottom: 0 !important;
+  left: 0 !important;
+
+  margin: 0 auto;
+  position: relative;
 
   span {
     flex: 1;

--- a/src/scss/main/_layout.scss
+++ b/src/scss/main/_layout.scss
@@ -136,8 +136,13 @@ body {
 }
 
 #toasts {
-  width: $full-width;
-  z-index: 70;
+  position: fixed;
+  z-index: 100;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: $toast-height;
+  overflow-y: hidden;
 }
 
 #commentbox {

--- a/src/scss/main/_layout.scss
+++ b/src/scss/main/_layout.scss
@@ -6,7 +6,7 @@
 
 body {
   @include flex (column, flex-start, center);
-  overflow-y: hidden !important;
+  overflow-y: auto !important;
   //angular adds overflow-y:scroll when activating md-select for some reason
 }
 
@@ -21,7 +21,7 @@ body {
     transform: scale(1.2);
     opacity: 0;
   }
-  
+
   img {
     width: 300px;
     margin-bottom: $padding-medium;
@@ -38,6 +38,7 @@ body {
   width: 100%;
   background: #000;
   z-index: 50;
+  min-height: 230px;
 }
 
 #header-toolbar {
@@ -180,6 +181,10 @@ body {
 main {
   @include flex (column, flex-start, center);
   width: 100%;
+
+  // Never be shorter than the comment box, which has height: 500px but is
+  // also offset by margin-top: -100px
+  min-height: 400px;
 }
 
 #notifications {

--- a/src/scss/main/_layout.scss
+++ b/src/scss/main/_layout.scss
@@ -38,7 +38,7 @@ body {
   width: 100%;
   background: #000;
   z-index: 50;
-  min-height: 230px;
+  min-height: $navbar-height + $header-image-height;
 }
 
 #header-toolbar {
@@ -189,7 +189,7 @@ main {
 
   // Never be shorter than the comment box, which has height: 500px but is
   // also offset by margin-top: -100px
-  min-height: 400px;
+  min-height: $commentbox-height + ($commentbox-top + $navbar-height - $header-height);
 }
 
 #notifications {

--- a/src/scss/main/_theme.scss
+++ b/src/scss/main/_theme.scss
@@ -48,9 +48,11 @@ $themes-list: (
 
   body.#{themeVar(selector)} {
 
-    background: $body-color;
-    color: $text-color-medium;
+    main {
+      background: $body-color;
+    }
 
+    color: $text-color-medium;
 
     /*======================================
                   OTHERS
@@ -174,7 +176,7 @@ $themes-list: (
 
     .current-lobby {
       background-color: white;
-      color: $text-color-medium;      
+      color: $text-color-medium;
     }
 
     #header-toolbar {
@@ -312,10 +314,10 @@ $themes-list: (
       background-color: $sheet-color;
     }
 
-    //SLIDER 
+    //SLIDER
     .md-thumb-text {
       color: white;
     }
-    
+
   }
 }


### PR DESCRIPTION
This is only the case if the viewport is too short to show the bottom of
the comment box (as the main section scrolls by itself). To prevent an
unstyled area from appearing, the main section also has to be forced to
never be shorter than the comment box.