### PR TITLE
Angular material 1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "angular": "~1.4.7",
     "angular-animate": "~1.4.0",
     "angular-audio": "~1.7.1",
-    "angular-material": "1.0.0-rc4",
+    "angular-material": "1.0.0",
     "angular-scroll-glue": "~2.0.6",
     "angular-ui-router": "~0.2.15",
     "clipboard": "~1.5.3",

--- a/src/app/app.notifications.js
+++ b/src/app/app.notifications.js
@@ -25,6 +25,7 @@
       bindToController: true,
       error: false,
       parent: $document[0].querySelector('#toasts'),
+      autoWrap: false,
       hideDelay: 0
     };
 

--- a/src/scss/main/_elements.scss
+++ b/src/scss/main/_elements.scss
@@ -183,14 +183,24 @@
   will-change: transform;
   transition: all .3s .15s ease-out;
   border-radius: 0;
+  align-items: center;
+  display: flex;
+  font-size: 14px;
 
   // Override some angular positioning (since we're moving the toasts
   // to the bottom of the viewport by ourselves)
   bottom: 0 !important;
   left: 0 !important;
 
+  padding-left: 24px;
+  padding-right: 24px;
+
   margin: 0 auto;
   position: relative;
+
+  button.md-button {
+    margin-right: 8px;
+  }
 
   span {
     flex: 1;

--- a/src/scss/main/_elements.scss
+++ b/src/scss/main/_elements.scss
@@ -176,15 +176,13 @@
    ================================== */
 
 .toast {
-  //@include flex (row, space-between, center);
+  @include flex (row, space-between, center);
   height: $toast-height;
   width: 100%;
   max-width: $full-width;
   will-change: transform;
   transition: all .3s .15s ease-out;
   border-radius: 0;
-  align-items: center;
-  display: flex;
   font-size: 14px;
 
   // Override some angular positioning (since we're moving the toasts

--- a/src/scss/main/_layout.scss
+++ b/src/scss/main/_layout.scss
@@ -250,3 +250,10 @@ main {
 md-dialog-content {
   padding: $padding-medium;
 }
+
+md-input-container {
+  // Temporary fix for https://github.com/angular/material/issues/6214
+  .md-errors-spacer {
+    min-height: 0 !important;
+  }
+}

--- a/src/scss/main/_theme.scss
+++ b/src/scss/main/_theme.scss
@@ -327,5 +327,10 @@ $themes-list: (
       color: white;
     }
 
+    //CHECKBOXES
+    .md-checked .md-icon:after {
+      border-color: $sheet-color !important;
+    }
+
   }
 }

--- a/src/scss/main/_theme.scss
+++ b/src/scss/main/_theme.scss
@@ -9,7 +9,9 @@ $themes-list: (
     text-color-hard:      $grey-hard,
     text-color-medium:    $grey-medium,
     text-color-light:     $grey-light,
-    shadow-multiplier:    1
+    shadow-multiplier:    1,
+    toast-background:     #323232,
+    toast-error-background:  #f77
   ),
   theme-map-dark: (
     selector:             'dark-theme',
@@ -21,7 +23,9 @@ $themes-list: (
     text-color-hard:      $grey-light,
     text-color-medium:    $grey-medium,
     text-color-light:     $grey-hard,
-    shadow-multiplier:    1.7
+    shadow-multiplier:    1.7,
+    toast-background:     #323232,
+    toast-error-background:  #f77
   )
 );
 
@@ -43,6 +47,8 @@ $themes-list: (
   $text-color-hard:       themeVar(text-color-hard);
   $text-color-medium:     themeVar(text-color-medium);
   $text-color-light:      themeVar(text-color-light);
+  $toast-color:           themeVar(toast-background);
+  $toast-error-color:     themeVar(toast-error-background);
   $shadow-multiplier:     themeVar(shadow-multiplier);
 
 
@@ -60,9 +66,11 @@ $themes-list: (
 
     .toast {
       color: $white-dirty;
+      background-color: $toast-color;
+      box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.26 * $shadow-multiplier);
 
       &.error {
-        background-color: #f77;
+        background-color: $toast-error-color;
         color: $white;
 
         .md-button {

--- a/src/scss/main/_theme.scss
+++ b/src/scss/main/_theme.scss
@@ -65,9 +65,11 @@ $themes-list: (
      =======================================*/
 
     .toast {
+      @extend %md-whiteframe-z2;
+      border-radius: 0 !important;
+
       color: $white-dirty;
       background-color: $toast-color;
-      box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.26 * $shadow-multiplier);
 
       &.error {
         background-color: $toast-error-color;
@@ -95,19 +97,22 @@ $themes-list: (
       border-radius: 3px;
       box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.14  * $shadow-multiplier),
                   0px 2px 2px  0px rgba(0, 0, 0, 0.098 * $shadow-multiplier),
-                  0px 1px 5px  0px rgba(0, 0, 0, 0.084 * $shadow-multiplier); }
+                  0px 1px 5px  0px rgba(0, 0, 0, 0.084 * $shadow-multiplier);
+    }
 
     %md-whiteframe-z2 {
       border-radius: 3px;
       box-shadow: 0px 2px 4px -1px rgba(0, 0, 0, 0.14  * $shadow-multiplier),
                   0px 4px 5px  0px rgba(0, 0, 0, 0.098 * $shadow-multiplier),
-                  0px 1px 10px 0px rgba(0, 0, 0, 0.084 * $shadow-multiplier); }
+                  0px 1px 10px 0px rgba(0, 0, 0, 0.084 * $shadow-multiplier);
+    }
 
     %md-whiteframe-z3 {
       border-radius: 3px;
       box-shadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.14  * $shadow-multiplier),
                   0px 6px 10px 0px rgba(0, 0, 0, 0.098 * $shadow-multiplier),
-                  0px 1px 18px 0px rgba(0, 0, 0, 0.084 * $shadow-multiplier); }
+                  0px 1px 18px 0px rgba(0, 0, 0, 0.084 * $shadow-multiplier);
+    }
 
 
     /*======================================

--- a/src/scss/pages/lobby-page/_lobby-page.scss
+++ b/src/scss/pages/lobby-page/_lobby-page.scss
@@ -148,7 +148,18 @@
 
   md-checkbox {
     margin: 0 auto;
-    width: 15px;
+    width: 18px;
+    padding: 5px 0 5px;
+
+    div.md-container {
+      width: 18px;
+      height: 18px;
+
+      .md-icon {
+        width: 18px;
+        height: 18px;
+      }
+    }
   }
 
   &:not(.sheet) > .md-ripple-container {

--- a/src/scss/pages/shared/_commentbox.scss
+++ b/src/scss/pages/shared/_commentbox.scss
@@ -15,6 +15,10 @@
     margin-top: $padding-medium;
   }
 
+  > md-input-container {
+    margin-bottom: 0;
+  }
+
   ul {
     padding: 0 $padding-small 0;
     margin: 0;


### PR DESCRIPTION
angular-material 1.0.0 reworked toasts by moving most of their styling
onto a wrapper div that they're (optionally) created in. However, this
wrapper div also has additional, reactive layout rules that don't make
sense for our site, so this change disables the wrapper div (autoWrap
setting in app.notifications.js) and re-adds to .toast the styles that
used to be on md-toast elements by default.

The toast background color and box-shadow are now always set by
_theme.scss (previously we were using the angular-material defaults).