### PR TITLE
Test faster

### DIFF
--- a/gulp/test.js
+++ b/gulp/test.js
@@ -29,7 +29,6 @@ gulp.task('test:unit', function (done) {
             'node_modules/es5-shim/es5-shim.js',
             src_files,
             'test/karma/**/*.js'),
-        logLevel: 'DEBUG',
         singleRun: true
       });
 

--- a/gulp/test.js
+++ b/gulp/test.js
@@ -10,26 +10,38 @@ var karma = require('karma');
 var $ = require('gulp-load-plugins')();
 
 gulp.task('test:unit', function (done) {
-  var server = new karma.Server({
-    browsers: ['PhantomJS'],
-    frameworks: ['mocha', 'chai-sinon'],
-    files: mainBowerFiles({ includeDev: true }).concat([
-      'dist/scripts/app-*.js',
-      'test/karma/**/*.js'
-    ]),
-    logLevel: 'DEBUG',
-    singleRun: true
-  });
+  var src_files = [];
+  gulp.src(path.join(conf.paths.src, '/app/**/*.js'))
+    .pipe($.angularFilesort())
+    .on('data', function (file) {
+      src_files.push(file.path);
+    }).on('end', function () {
+      var server = new karma.Server({
+        browsers: ['PhantomJS'],
+        frameworks: ['mocha', 'chai-sinon'],
+        files:
+        mainBowerFiles({ includeDev: true })
+          .concat(
+            // Note: es5-shim needed to fix some phantomjs issues,
+            // including no Function.prototype.bind . This can be
+            // removed (along with the es5-shim dependency) once an
+            // upgrade to phantomjs2 is complete
+            'node_modules/es5-shim/es5-shim.js',
+            src_files,
+            'test/karma/**/*.js'),
+        logLevel: 'DEBUG',
+        singleRun: true
+      });
 
-  server.on('run_complete', function (browsers, results) {
-    // NB If the argument of done() is not null or not undefined,
-    // e.g. a string, the next task in a series won't run.
-    done(results.error ? 'There are test failures' : null);
-  });
-
-  server.start();
+      server.on('run_complete', function (browsers, results) {
+        // NB If the argument of done() is not null or not undefined,
+        // e.g. a string, the next task in a series won't run.
+        done(results.error ? 'There are test failures' : null);
+      });
+      server.start();
+    });
 });
 
 gulp.task('test', function (cb) {
-  runSequence('build', 'test:unit', cb);
+  runSequence('test:unit', cb);
 });

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chalk": "^1.1.1",
     "concat-stream": "~1.5.0",
     "connect-history-api-fallback": "^1.1.0",
+    "es5-shim": "^4.4.1",
     "eslint": "^1.10.1",
     "eslint-plugin-angular": "^0.14.0",
     "glob": "^6.0.1",


### PR DESCRIPTION
requires re-running `npm install`

`gulp test` should now run far faster as it doesn't need a full rebuild each time. The many pages of DEBUG output is was printing are also silenced now.