### PR TITLE
Test coverage metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 src/assets/
 src/app/app.config.js
 Frontend.iml
+coverage/

--- a/gulp/test.js
+++ b/gulp/test.js
@@ -11,7 +11,12 @@ var $ = require('gulp-load-plugins')();
 
 function runUnitTestsOn(browsers, done) {
   var src_files = [];
-  gulp.src(path.join(conf.paths.src, '/app/**/*.js'))
+  var src_glob = path.join(conf.paths.src, '/app/**/*.js');
+
+  var preprocessors = {};
+  preprocessors[src_glob] = ['coverage'];
+
+  gulp.src(src_glob)
     .pipe($.angularFilesort())
     .on('data', function (file) {
       src_files.push(file.path);
@@ -29,7 +34,9 @@ function runUnitTestsOn(browsers, done) {
             'node_modules/es5-shim/es5-shim.js',
             src_files,
             path.join(conf.paths.test, '/karma/**/*.js')),
-        singleRun: true
+        singleRun: true,
+        reporters: ['progress', 'coverage'],
+        preprocessors: preprocessors
       });
 
       server.on('run_complete', function (browsers, results) {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "karma": "^0.13.15",
     "karma-chai-sinon": "^0.1.5",
     "karma-chrome-launcher": "^0.2.2",
+    "karma-coverage": "^0.5.3",
     "karma-firefox-launcher": "^0.1.7",
     "karma-mocha": "^0.2.1",
     "karma-phantomjs-launcher": "^0.2.1",


### PR DESCRIPTION
HTML reports generated in the `coverage/` directory (.gitignore'd) when running either `gulp test` or `gulp test-browsers`