### PR TITLE
lobby-create: move to string whitelist-ids

### DIFF
--- a/src/app/pages/lobby/create/lobby-create.provider.js
+++ b/src/app/pages/lobby/create/lobby-create.provider.js
@@ -228,52 +228,52 @@
           filterable: true,
           options: [
             {
-              value: 3250,
-              title: 'ETF2L Highlander (Season 8)',
+              value: 'etf2l_9v9_s9',
+              title: 'ETF2L Highlander (Season 9)',
               etf2l: true,
               highlander: true
             },{
-              value: 4498,
+              value: 'etf2l_6v6_s22',
               title: 'ETF2L 6v6 (Season 22)',
               etf2l: true,
               '6s': true
             },{
-              value: 3951,
-              title: 'UGC Highlander (Season 16)',
+              value: 'ugc_9v9_s19',
+              title: 'UGC Highlander (Season 19)',
               ugc: true,
               highlander: true
             },{
-              value: 4559,
+              value: 'ugc_6v6_s19',
               title: 'UGC 6v6 (Season 19)',
               ugc: true,
               '6s': true
             },{
-              value: 3771,
-              title: 'UGC 4v4 (Season 16)',
+              value: 'ugc_4v4_s6',
+              title: 'UGC 4v4 (Season 6)',
               ugc: true,
               '4v4': true
             },{
-              value: 3688,
-              title: 'ESEA 6v6 (Season 19)',
+              value: 'esea_6v6_s20',
+              title: 'ESEA 6v6 (Season 20)',
               esea: true,
               '6s': true
             },{
-              value: 4034,
+              value: 'ozfortress_6v6_s14',
               title: 'ozfortress 6v6 (OWL 14)',
               ozfortress: true,
               '6s': true
             },{
-              value: 3872,
+              value: 'asiafortress_6v6_s9',
               title: 'AsiaFortress 6v6 (Season 9)',
               asia: true,
               '6s': true
             },{
-              value: 3312,
+              value: 'etf2l_ultiduo',
               title: 'ETF2L Ultiduo',
               etf2l: true,
               ultiduo: true
             },{
-              value: 3759,
+              value: 'etf2l_bball',
               title: 'ETF2L BBall',
               etf2l: true,
               bball: true


### PR DESCRIPTION
This change (which affects the types of values sent for the lobbyCreate
request) lines up with Helen moving from numeric -> string whitelist.tf
IDs.

Additionally, updates some whitelists to the current seasons.