### PR TITLE
Use app.config.js.override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ bower_components/
 .tmp/
 dist/
 src/assets/
-src/app/app.config.js
+src/app/app.config.js.override
 Frontend.iml
 coverage/

--- a/gulp/conf.js
+++ b/gulp/conf.js
@@ -40,7 +40,13 @@ exports.shouldReplace = function(fname) {
   return fname.indexOf(configFile) > -1;
 };
 
-var noopStream = es.map(function (f, next) { next(null, f); });
+function isFile(path) {
+  try {
+    return fs.statSync(path).isFile();
+  } catch(err) {
+    return !(err && err.code === 'ENOENT');
+  }
+}
 
 /**
  *  Returns a stream creation function that creates streams to replace
@@ -55,7 +61,7 @@ exports.replaceConfig = function() {
   var overrideFile =
         path.join(exports.paths.src, 'app', configFile) + '.override';
 
-  if (fs.statSync(overrideFile).isFile()) {
+  if (isFile(overrideFile)) {
     return es.map(function (file, next) {
       if (exports.shouldReplace(file.path)) {
         toArray(vfs.src(overrideFile), function (err, arr) {
@@ -77,7 +83,7 @@ exports.replaceConfig = function() {
       }
     });
   } else {
-    return noopStream;
+    return es.map(function (f, next) { next(null, f); });;
   }
 };
 

--- a/gulp/conf.js
+++ b/gulp/conf.js
@@ -7,6 +7,11 @@
  */
 
 var gutil = require('gulp-util');
+var fs = require('fs');
+var es = require('event-stream');
+var path = require('path');
+var toArray = require('stream-to-array');
+var vfs = require('vinyl-fs');
 
 /**
  *  The main paths of your project handle these with care
@@ -27,6 +32,53 @@ exports.paths = {
 exports.wiredep = {
   exclude: [/foundation\.js/, /foundation\.css/],
   directory: 'bower_components'
+};
+
+var configFile = 'app.config.js';
+
+exports.shouldReplace = function(fname) {
+  return fname.indexOf(configFile) > -1;
+};
+
+var noopStream = es.map(function (f, next) { next(null, f); });
+
+/**
+ *  Returns a stream creation function that creates streams to replace
+ *  the config file with the config file + .override if the override
+ *  file is present.
+ *
+ *  eg, this can be used on a stream: `.pipe(conf.replaceConfig())`
+ *  and when that stream encounters the config file, it may be replaced with
+ *  the .override file
+ */
+exports.replaceConfig = function() {
+  var overrideFile =
+        path.join(exports.paths.src, 'app', configFile) + '.override';
+
+  if (fs.statSync(overrideFile).isFile()) {
+    return es.map(function (file, next) {
+      if (exports.shouldReplace(file.path)) {
+        toArray(vfs.src(overrideFile), function (err, arr) {
+          if (err) {
+            gutil.log('Error loading site-specific config', err);
+          } else {
+            gutil.log('Using site-specific config', arr[0].path);
+
+            // We need to modify the original file; just doing
+            // next(null, arr[0]) might trip up later stream processes
+            // which rely on the filename to end in .js
+            file.contents = arr[0].contents;
+          }
+
+          next(null, file);
+        });
+      } else {
+        next(null, file);
+      }
+    });
+  } else {
+    return noopStream;
+  }
 };
 
 /**

--- a/gulp/inject.js
+++ b/gulp/inject.js
@@ -21,6 +21,7 @@ gulp.task('inject', ['scripts', 'styles'], function () {
     path.join('!' + conf.paths.src, '/app/**/*.spec.js'),
     path.join('!' + conf.paths.src, '/app/**/*.mock.js')
   ])
+  .pipe(conf.replaceConfig())
   .pipe($.angularFilesort()).on('error', conf.errorHandler('AngularFilesort'));
 
   var injectOptions = {
@@ -47,6 +48,7 @@ gulp.task('build:inject', ['build:styles'], function () {
     path.join('!' + conf.paths.src, '/app/**/*.spec.js'),
     path.join('!' + conf.paths.src, '/app/**/*.mock.js')
   ])
+  .pipe(conf.replaceConfig())
   .pipe($.angularFilesort()).on('error', conf.errorHandler('AngularFilesort'));
 
   var injectOptions = {

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -13,6 +13,7 @@ gulp.task('scripts', function () {
   return gulp.src(path.join(conf.paths.src, '/app/**/*.js'))
     .pipe($.eslint())
     .pipe($.eslint.format())
+    .pipe(conf.replaceConfig())
     .pipe(browserSync.reload({ stream: true }))
     .pipe($.size());
 });

--- a/gulp/server.js
+++ b/gulp/server.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var path = require('path');
 var gulp = require('gulp');
 var conf = require('./conf');
@@ -42,7 +43,18 @@ function browserSyncInit(baseDir, browser) {
     startPath: '/',
     server: server,
     browser: browser,
-    middleware: [historyApiFallback()]
+    middleware: [
+      historyApiFallback(),
+      function (req, res, next) {
+        if (conf.shouldReplace(req.url)) {
+          var replaceWith = path.join(conf.paths.src, req.url + '.override');
+          if (fs.statSync(replaceWith).isFile()) {
+            req.url += '.override';
+          }
+        }
+        next();
+      }
+    ]
   });
 
 

--- a/gulp/test.js
+++ b/gulp/test.js
@@ -12,7 +12,9 @@ var $ = require('gulp-load-plugins')();
 
 function runUnitTestsOn(browsers, done) {
   var srcGlob = path.join(conf.paths.src, '/app/**/*.js');
-  var src = gulp.src(srcGlob).pipe($.angularFilesort());
+  var src = gulp.src(srcGlob)
+        .pipe(conf.replaceConfig())
+        .pipe($.angularFilesort());
 
   var preprocessors = {};
   preprocessors[srcGlob] = ['coverage'];

--- a/gulp/test.js
+++ b/gulp/test.js
@@ -6,46 +6,43 @@ var mainBowerFiles = require('main-bower-files');
 var gulp = require('gulp');
 var conf = require('./conf');
 var karma = require('karma');
+var toArray = require('stream-to-array');
 
 var $ = require('gulp-load-plugins')();
 
 function runUnitTestsOn(browsers, done) {
-  var src_files = [];
-  var src_glob = path.join(conf.paths.src, '/app/**/*.js');
+  var srcGlob = path.join(conf.paths.src, '/app/**/*.js');
+  var src = gulp.src(srcGlob).pipe($.angularFilesort());
 
   var preprocessors = {};
-  preprocessors[src_glob] = ['coverage'];
+  preprocessors[srcGlob] = ['coverage'];
 
-  gulp.src(src_glob)
-    .pipe($.angularFilesort())
-    .on('data', function (file) {
-      src_files.push(file.path);
-    }).on('end', function () {
-      var server = new karma.Server({
-        browsers: browsers,
-        frameworks: ['mocha', 'chai-sinon'],
-        files:
-        mainBowerFiles({ includeDev: true })
-          .concat(
-            // Note: es5-shim needed to fix some phantomjs issues,
-            // including no Function.prototype.bind . This can be
-            // removed (along with the es5-shim dependency) once an
-            // upgrade to phantomjs2 is complete
-            'node_modules/es5-shim/es5-shim.js',
-            src_files,
-            path.join(conf.paths.test, '/karma/**/*.js')),
-        singleRun: true,
-        reporters: ['progress', 'coverage'],
-        preprocessors: preprocessors
-      });
-
-      server.on('run_complete', function (browsers, results) {
-        // NB If the argument of done() is not null or not undefined,
-        // e.g. a string, the next task in a series won't run.
-        done(results.error ? 'There are test failures' : null);
-      });
-      server.start();
+  toArray(src, function (err, srcFiles) {
+    var server = new karma.Server({
+      browsers: browsers,
+      frameworks: ['mocha', 'chai-sinon'],
+      files:
+      mainBowerFiles({ includeDev: true })
+        .concat(
+          // Note: es5-shim needed to fix some phantomjs issues,
+          // including no Function.prototype.bind . This can be
+          // removed (along with the es5-shim dependency) once an
+          // upgrade to phantomjs2 is complete
+          'node_modules/es5-shim/es5-shim.js',
+          srcFiles.map(function (f) { return f.path; }),
+          path.join(conf.paths.test, '/karma/**/*.js')),
+      singleRun: true,
+      reporters: ['progress', 'coverage'],
+      preprocessors: preprocessors
     });
+
+    server.on('run_complete', function (browsers, results) {
+      // NB If the argument of done() is not null or not undefined,
+      // e.g. a string, the next task in a series won't run.
+      done(results.error ? 'There are test failures' : null);
+    });
+    server.start();
+  });
 }
 
 gulp.task('test:unit', function (done) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-sass": "~2.0.1",
     "gulp-sourcemaps": "~1.5.2",
     "gulp-uglify": "~1.2.0",
-    "gulp-useref": "~1.2.0",
+    "gulp-useref": "~3.0.4",
     "gulp-util": "~3.0.5",
     "gulp-if": "^2.0.0",
     "lodash": "~3.9.3",
@@ -44,6 +44,7 @@
     "es5-shim": "^4.4.1",
     "eslint": "^1.10.1",
     "eslint-plugin-angular": "^0.14.0",
+    "event-stream": "^3.3.2",
     "glob": "^6.0.1",
     "gulp-eslint": "^1.1.1",
     "gulp-karma": "0.0.5",
@@ -59,6 +60,7 @@
     "karma-firefox-launcher": "^0.1.7",
     "karma-mocha": "^0.2.1",
     "karma-phantomjs-launcher": "^0.2.1",
+    "lazypipe": "^1.0.1",
     "merge-stream": "~0.1.7",
     "mocha": "^2.3.4",
     "phantomjs": "^1.9.19",
@@ -66,7 +68,9 @@
     "run-sequence": "^1.1.5",
     "selenium-webdriver": "^2.48.2",
     "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "stream-to-array": "^2.2.0",
+    "vinyl-fs": "^2.2.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Finally un-ignores `app.config.js`. Now, you can copy `app.config.js` to `app.config.js.override` and all relevant `gulp` tasks should use that `.override` file instead of the normal `app.config.js` (Only if the `.override` file is present, otherwise everything will work as normal)