### PR TITLE
Fix toasts blocking clicks, even when invisible

### DIFF
--- a/src/scss/main/_layout.scss
+++ b/src/scss/main/_layout.scss
@@ -141,7 +141,6 @@ body {
   bottom: 0;
   left: 0;
   width: 100%;
-  height: $toast-height;
   overflow-y: hidden;
 }
 


### PR DESCRIPTION
fix toasts stopping you from clicking near the bottom of the page, even
when none are present