### PR TITLE
upgrade to angular 1.5.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,8 +6,9 @@
   "readme": "readme.md",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "~1.4.9",
-    "angular-animate": "~1.4.9",
+    "angular": "1.5.0",
+    "angular-animate": "1.5.0",
+    "angular-aria": "1.5.0",
     "angular-audio": "~1.7.1",
     "angular-material": "1.0.4",
     "angular-scroll-glue": "~2.0.6",
@@ -19,6 +20,9 @@
     "xss-filters": "~1.2.6"
   },
   "devDependencies": {
-    "angular-mocks": "~1.4.9"
+    "angular-mocks": "1.5.0"
+  },
+  "resolutions": {
+    "angular": "1.5.0"
   }
 }


### PR DESCRIPTION
Note: ngAudio now has some dependency weirdness that requires a
"resolutions" key in bower.json to override the fact that
ngAudio (seemingly arbitrarily) requests angular<1.5

Signed-off-by: gpittarelli tf2stadium@gjp.cc
