### PR TITLE
remove gray shadow from lobby-list header

### DIFF
--- a/src/app/pages/lobby/list/header.html
+++ b/src/app/pages/lobby/list/header.html
@@ -1,4 +1,4 @@
-<div class="header-text">
+<div class="header-text-no-darken">
   <div class="lobbylist-text">
     <md-switch id="filters-checkbox"
       ng-model="header.filtersEnabled"

--- a/src/scss/main/_layout.scss
+++ b/src/scss/main/_layout.scss
@@ -96,17 +96,21 @@ body {
   }
 }
 
-.header-text {
+.header-text,
+.header-text-no-darken {
   width: $full-width;
   height: 100%;
   padding: 0 $commentbox-width 0 $left-sidebar-width;
+}
+
+.header-text {
   background-image: linear-gradient(
-      to right,
-      rgba(0, 0, 0, 0) 0%,
-      rgba(0, 0, 0, .4) 10%,
-      rgba(0, 0, 0, .4) 90%,
-      rgba(0, 0, 0, 0) 100%
-  );
+                        to right,
+                        rgba(0, 0, 0, 0) 0%,
+                        rgba(0, 0, 0, .4) 10%,
+                        rgba(0, 0, 0, .4) 90%,
+                        rgba(0, 0, 0, 0) 100%
+                      );
 }
 
 #fab {

--- a/src/scss/pages/lobby-list/_lobby-list.scss
+++ b/src/scss/pages/lobby-list/_lobby-list.scss
@@ -13,6 +13,7 @@
   bottom: $padding-small;
   right: $padding-medium;
   margin: 0;
+  text-shadow: #000 0 0 12px;
 }
 
 


### PR DESCRIPTION
To help highlight our new, very pretty background images. Instead, add a
small text shadow to the filters checkbox.

Signed-off-by: gpittarelli tf2stadium@gjp.cc
