### PR TITLE
cinemagraph: unload when window isn't focused

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
     "Socket": false,
     "Clipboard": false,
     "xssFilters": false,
-    "moment": false
+    "moment": false,
+    "Kefir": false
   },
   "rules": {
     "no-console": 0,

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "angular-ui-validate": "~1.2.2",
     "xss-filters": "~1.2.6",
     "moment": "~2.11.2",
-    "ng-media-events": "~1.0.1"
+    "ng-media-events": "~1.0.1",
+    "kefir": "~3.2.0"
   },
   "devDependencies": {
     "angular-mocks": "1.5.0"

--- a/src/app/shared/user.factory.js
+++ b/src/app/shared/user.factory.js
@@ -34,7 +34,7 @@
     };
 
     userService.twitchLogout = function () {
-      $window.open(Config.endpoints.api+'/twitchLogout', '_self');
+      $window.open(Config.endpoints.api + '/twitchLogout', '_self');
     };
 
     userService.init = function () {

--- a/src/app/shared/video.directive.js
+++ b/src/app/shared/video.directive.js
@@ -6,11 +6,16 @@
 
   /** @ngInject */
   function VideoBackgroundDirective($rootScope, Settings) {
+    var focused = Kefir.merge([
+      Kefir.fromEvents(window, 'focus').map(function () { return true; }),
+      Kefir.fromEvents(window, 'blur').map(function () { return false; })
+    ]);
+
     return {
       restrict: 'E',
       scope: {},
       template:
-        '<video ng-if="showVideo" ng-show="videoReady" ng-canplay="canPlay()" autoplay autostart loop class="cinemagraph">' +
+        '<video ng-if="showVideo && pageFocused" ng-show="videoReady" ng-canplay="canPlay()" autoplay autostart loop class="cinemagraph">' +
         '<source src="/assets/video/koth_suijin.vp9.webm" type=\'video/webm;codecs="vp9"\' />'+
         '<source src="/assets/video/koth_suijin.vp8.webm" type=\'video/webm;codecs="vp8"\' />' +
         '<source src="/assets/video/koth_suijin.h264.mp4" type="video/mp4" />' +
@@ -18,8 +23,19 @@
 
       link: function (scope) {
         scope.showVideo = false;
+        scope.pageFocused = true;
 
-        // used via ng-show to prevent a black flash from displaying
+        focused.onValue(function (isFocused) {
+          scope.$apply(function () {
+            if (!scope.pageFocused && isFocused) {
+              scope.videoReady = false;
+            }
+
+            scope.pageFocused = isFocused;
+          });
+        });
+
+        // use ng-show to prevent a black flash from displaying
         // an unloaded video when the videoBackground setting changes
         scope.videoReady = false;
         scope.canPlay = function () {


### PR DESCRIPTION
This is to address performance concerns when palyers have the
cinemagraph enabled, but focus another window (say, TF2).

Signed-off-by: gpittarelli tf2stadium@gjp.cc
