### PR TITLE
remove unneeded border-radius on header

### DIFF
--- a/src/scss/main/_layout.scss
+++ b/src/scss/main/_layout.scss
@@ -48,6 +48,9 @@ body {
   @extend .sheet;
   min-height: $navbar-height;
 
+  // Override the border-radius set by .sheet
+  border-radius: 0;
+
   .header-toolbar-content {
     @include flex (row, center, center);
     width: $full-width;


### PR DESCRIPTION
this was effectively adding some white dots that were highly visible on
the dark theme.

Signed-off-by: gpittarelli tf2stadium@gjp.cc
