### PR TITLE
chat box: track messages by id

### DIFF
--- a/src/app/shared/comment-box/comment-box.html
+++ b/src/app/shared/comment-box/comment-box.html
@@ -17,7 +17,7 @@
         </md-tab-label>
         <md-tab-body>
           <md-content scroll-glue>
-            <div ng-repeat="message in room.messages track by $index"
+            <div ng-repeat="message in room.messages track by message.id"
                  class="chat-message">
               <span class="chat-message-time"
                     ng-if="$root.currentTimestampsOption !== 'none'"


### PR DESCRIPTION
should prevent messages being displayed with the wrong name after the
chat log truncation

Signed-off-by: George Pittarelli g@gjp.cc
