### PR TITLE
Embed config in index.html instead of in JS bundles

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,6 +1,5 @@
 /* @flow */
 import angular from 'angular';
-import config from 'app-config';
 import ngreact from 'ngreact';
 import scrollglue from './scrollglue';
 import { isEmpty } from 'lodash';
@@ -16,6 +15,8 @@ import { WhitelistDirective, AutofocusDirective } from './app.directive';
 import buildStats from './build-stats';
 
 import '../scss/app.scss';
+
+const config = window.config;
 
 var modules = [],
   release = 'development';

--- a/src/index.html
+++ b/src/index.html
@@ -16,6 +16,7 @@
     <meta name="twitter:title" content="TF2Stadium"/>
     <meta name="twitter:description" content="The free and open source TF2 lobby website"/>
     <base href="/">
+    <script>window.config=<%=JSON.stringify(require('app-config'))%>;</script>
   </head>
   <body class="md-menu-{{$root.currentTheme || 'default-theme'}}">
     <div id="app-container" class="{{$root.currentTheme || 'default-theme'}} {{$root.animationLength || 'animation-normal'}}">


### PR DESCRIPTION
This is prep for docker improvements -- running `sed` on cached asset
files is bad.  But index.html is never cached.